### PR TITLE
docs: add third-party license notices

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,11 @@
+MemFlywheel
+Copyright 2026 iFLYTEK CO., LTD.
+
+This product includes software developed at:
+- TypeBox (https://github.com/sinclairzx81/typebox), licensed under MIT License
+- TypeScript (https://www.typescriptlang.org/), licensed under Apache License 2.0
+- DefinitelyTyped Node.js type definitions (https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node), licensed under MIT License
+- undici-types (https://undici.nodejs.org), licensed under MIT License
+
+Third-party licenses are listed in the THIRD_PARTY_LICENSES file.
+For the main project license, see LICENSE.

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1,0 +1,60 @@
+Third-Party Licenses
+====================
+
+This file lists third-party npm packages used by the MemFlywheel source
+workspace for build, test, and type-checking. The MemFlywheel packages
+themselves are licensed under the repository LICENSE file.
+
+Package: typebox
+Version: 1.2.19
+Homepage: https://github.com/sinclairzx81/typebox
+License: MIT
+Copyright: Copyright (c) 2017-2026 Haydn Paterson
+
+Package: typescript
+Version: 5.9.3
+Homepage: https://www.typescriptlang.org/
+License: Apache-2.0
+Copyright: Microsoft Corp.
+
+Package: @types/node
+Version: 22.19.21
+Homepage: https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/node
+License: MIT
+Copyright: Copyright (c) Microsoft Corporation.
+
+Package: undici-types
+Version: 6.21.0
+Homepage: https://undici.nodejs.org
+License: MIT
+Copyright: Copyright (c) Matteo Collina and Undici contributors
+
+
+MIT License Text
+----------------
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+Apache-2.0 License Text
+-----------------------
+
+TypeScript is licensed under the Apache License, Version 2.0. The full
+Apache-2.0 license text is available in this repository's LICENSE file and at:
+https://www.apache.org/licenses/LICENSE-2.0


### PR DESCRIPTION
## Summary

- Add root NOTICE with MemFlywheel copyright and third-party package notices
- Add THIRD_PARTY_LICENSES with package versions, license identifiers, copyright notices, and license text pointers

## Checks

- [x] pnpm run ci
- [x] git diff --check

## Notes

This covers the source workspace third-party npm packages used for build, test, and type-checking. The published @memflywheel/* package dry-runs show no bundled third-party dependencies.