### PR TITLE
feat(ci): publish public packages to both npm and GitHub Packages with dual-scope support

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -39,4 +39,4 @@ jobs:
         run: pnpm run build
 
       - name: Publish preview
-        run: pnpx pkg-pr-new publish
+        run: pnpx pkg-pr-new publish packages/adapters packages/hermes-plugin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   contents: read
   id-token: write
+  packages: write
 
 jobs:
   release:
@@ -53,3 +54,11 @@ jobs:
         run: pnpm run publish:npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to GitHub Packages
+        run: |
+          echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" > .npmrc
+          pnpm run publish:npm -- --registry=https://npm.pkg.github.com
+          rm .npmrc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 dist/
 *.tsbuildinfo
 .turbo/
+.npmrc
 
 # ==============================
 # System / OS Files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,13 @@ for published packages.
   mirror.
 - npm release workflow, package dry-run checks, and release documentation.
 - Runnable examples for Pi, Hermes, OpenCode, and OpenClaw.
+- Dual-registry publishing: npm (`@iflytekopensource/*`) and GitHub Packages
+  (`@iflytek/*`) via `scripts/publish-npm.mjs`.
+
+### Fixed
+
+- Preview release workflow: explicitly specify public package paths for
+  `pkg-pr-new publish` to resolve `No packages` error when internal packages are
+  marked `private: true`.
+- Added `.npmrc` to `.gitignore` to prevent accidental commit of temporary auth
+  tokens.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,7 @@ for published packages.
   marked `private: true`.
 - Added `.npmrc` to `.gitignore` to prevent accidental commit of temporary auth
   tokens.
+- GitHub Packages publishing: rewrite runtime adapter imports in Hermes package
+  (`bin/install.mjs`, `bridge/worker.mjs`, `provider/__init__.py`) from
+  `@iflytekopensource/adapters` to `@iflytek/adapters` to match the rewritten
+  dependency scope.

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -1,19 +1,97 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const packages = ["@iflytekopensource/adapters", "@iflytekopensource/hermes"];
 
-const extraArgs = process.argv.slice(2).filter((arg) => arg !== "--");
-const hasDistTag = extraArgs.some((arg) => arg === "--tag" || arg.startsWith("--tag="));
-const publishArgs = hasDistTag ? extraArgs : ["--tag", "latest", ...extraArgs];
+function parseArgs() {
+  const args = process.argv.slice(2).filter((arg) => arg !== "--");
+  let registry;
+  const publishArgs = [];
 
-for (const packageName of packages) {
-  const result = spawnSync(
-    "pnpm",
-    ["--filter", packageName, "publish", "--access", "public", "--no-git-checks", ...publishArgs],
-    { stdio: "inherit" },
-  );
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1);
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === "--registry" && args[i + 1]) {
+      registry = args[++i];
+    } else if (args[i].startsWith("--registry=")) {
+      registry = args[i].slice("--registry=".length);
+    } else {
+      publishArgs.push(args[i]);
+    }
   }
+
+  const hasDistTag = publishArgs.some((a) => a === "--tag" || a.startsWith("--tag="));
+  if (!hasDistTag) publishArgs.unshift("--tag", "latest");
+
+  return { registry, publishArgs };
+}
+
+function buildArgs({ publishArgs, registry, access }) {
+  const args = ["publish", "--no-git-checks", ...publishArgs];
+  if (registry) args.push("--registry", registry);
+  if (access) args.push("--access", access);
+  return args;
+}
+
+async function publishToGitHubPackages({ publishArgs }) {
+  const staging = mkdtempSync(join(tmpdir(), "ghpkg-"));
+
+  try {
+    for (const pkg of packages) {
+      const pack = spawnSync("pnpm", ["--filter", pkg, "pack", "--pack-destination", staging], {
+        stdio: "inherit",
+      });
+      if (pack.status !== 0) process.exit(pack.status ?? 1);
+    }
+
+    for (const tarball of spawnSync("ls", [staging], { encoding: "utf8" })
+      .stdout.trim()
+      .split("\n")
+      .filter(Boolean)) {
+      const dir = join(staging, tarball.replace(".tgz", ""));
+      mkdirSync(dir);
+      spawnSync("tar", ["xzf", join(staging, tarball), "-C", dir, "package"], { stdio: "inherit" });
+
+      const pjPath = join(dir, "package", "package.json");
+      const pj = JSON.parse(readFileSync(pjPath, "utf8"));
+      pj.name = pj.name.replace("@iflytekopensource/", "@iflytek/");
+      for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
+        if (pj[field]) {
+          for (const [k, v] of Object.entries(pj[field])) {
+            if (k.startsWith("@iflytekopensource/")) {
+              delete pj[field][k];
+              pj[field][k.replace("@iflytekopensource/", "@iflytek/")] = v;
+            }
+          }
+        }
+      }
+      writeFileSync(pjPath, JSON.stringify(pj, null, 2) + "\n");
+
+      const result = spawnSync(
+        "npm",
+        ["publish", "./package", "--registry", "https://npm.pkg.github.com", "--access", "public"],
+        { stdio: "inherit", env: { ...process.env, NODE_AUTH_TOKEN: process.env.GITHUB_TOKEN } },
+      );
+      if (result.status !== 0) process.exit(result.status ?? 1);
+    }
+  } finally {
+    rmSync(staging, { recursive: true, force: true });
+  }
+}
+
+function publishToNpm({ publishArgs }) {
+  const args = buildArgs({ publishArgs, access: "public" });
+  for (const pkg of packages) {
+    const result = spawnSync("pnpm", ["--filter", pkg, ...args], { stdio: "inherit" });
+    if (result.status !== 0) process.exit(result.status ?? 1);
+  }
+}
+
+const { registry, publishArgs } = parseArgs();
+
+if (registry === "https://npm.pkg.github.com") {
+  await publishToGitHubPackages({ publishArgs });
+} else {
+  publishToNpm({ publishArgs });
 }

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -1,16 +1,22 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, readdirSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const packages = ["@iflytekopensource/adapters", "@iflytekopensource/hermes"];
+const GHP_REGISTRY = "https://npm.pkg.github.com";
+const SCOPE_FROM = "@iflytekopensource/";
+const SCOPE_TO = "@iflytek/";
+const TARGET_PACKAGES = ["@iflytekopensource/adapters", "@iflytekopensource/hermes"];
+
+function rewriteScope(value) {
+  return value.split(SCOPE_FROM).join(SCOPE_TO);
+}
 
 function parseArgs() {
-  const args = process.argv.slice(2).filter((arg) => arg !== "--");
+  const args = process.argv.slice(2).filter((a) => a !== "--");
   let registry;
   const publishArgs = [];
-
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--registry" && args[i + 1]) {
       registry = args[++i];
@@ -20,78 +26,85 @@ function parseArgs() {
       publishArgs.push(args[i]);
     }
   }
-
-  const hasDistTag = publishArgs.some((a) => a === "--tag" || a.startsWith("--tag="));
-  if (!hasDistTag) publishArgs.unshift("--tag", "latest");
-
+  if (!publishArgs.some((a) => a === "--tag" || a.startsWith("--tag="))) {
+    publishArgs.unshift("--tag", "latest");
+  }
   return { registry, publishArgs };
 }
 
-function buildArgs({ publishArgs, registry, access }) {
-  const args = ["publish", "--no-git-checks", ...publishArgs];
-  if (registry) args.push("--registry", registry);
-  if (access) args.push("--access", access);
-  return args;
+function run(cmd, args) {
+  const r = spawnSync(cmd, args, { stdio: "inherit" });
+  if (r.error) {
+    console.error(`Failed to run ${cmd}: ${r.error.message}`);
+    process.exit(1);
+  }
+  if (r.status !== 0) process.exit(r.status ?? 1);
 }
 
-async function publishToGitHubPackages({ publishArgs }) {
-  const staging = mkdtempSync(join(tmpdir(), "ghpkg-"));
+function publishToNpm(publishArgs) {
+  for (const pkg of TARGET_PACKAGES) {
+    run("pnpm", ["--filter", pkg, "publish", "--no-git-checks", "--access", "public", ...publishArgs]);
+  }
+}
 
+function publishToGitHubPackages(publishArgs) {
+  const staging = mkdtempSync(join(tmpdir(), "ghpkg-"));
   try {
-    for (const pkg of packages) {
-      const pack = spawnSync("pnpm", ["--filter", pkg, "pack", "--pack-destination", staging], {
-        stdio: "inherit",
-      });
-      if (pack.status !== 0) process.exit(pack.status ?? 1);
+    for (const pkg of TARGET_PACKAGES) {
+      run("pnpm", ["--filter", pkg, "pack", "--pack-destination", staging]);
     }
 
-    for (const tarball of spawnSync("ls", [staging], { encoding: "utf8" })
-      .stdout.trim()
-      .split("\n")
-      .filter(Boolean)) {
+    for (const tarball of readdirSync(staging).filter((f) => f.endsWith(".tgz"))) {
       const dir = join(staging, tarball.replace(".tgz", ""));
-      mkdirSync(dir);
-      spawnSync("tar", ["xzf", join(staging, tarball), "-C", dir, "package"], { stdio: "inherit" });
+      mkdirSync(dir, { recursive: true });
+      run("tar", ["xzf", join(staging, tarball), "-C", dir, "package"]);
 
-      const pjPath = join(dir, "package", "package.json");
+      const pkgDir = join(dir, "package");
+      const pjPath = join(pkgDir, "package.json");
       const pj = JSON.parse(readFileSync(pjPath, "utf8"));
-      pj.name = pj.name.replace("@iflytekopensource/", "@iflytek/");
+
+      // Rewrite package name and dependency keys
+      pj.name = rewriteScope(pj.name);
       for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
-        if (pj[field]) {
-          for (const [k, v] of Object.entries(pj[field])) {
-            if (k.startsWith("@iflytekopensource/")) {
-              delete pj[field][k];
-              pj[field][k.replace("@iflytekopensource/", "@iflytek/")] = v;
-            }
+        if (!pj[field]) continue;
+        for (const [k, v] of Object.entries(pj[field])) {
+          if (k.startsWith(SCOPE_FROM)) {
+            delete pj[field][k];
+            pj[field][rewriteScope(k)] = v;
           }
         }
       }
       writeFileSync(pjPath, JSON.stringify(pj, null, 2) + "\n");
 
-      const result = spawnSync(
-        "npm",
-        ["publish", "./package", "--registry", "https://npm.pkg.github.com", "--access", "public"],
-        { stdio: "inherit", env: { ...process.env, NODE_AUTH_TOKEN: process.env.GITHUB_TOKEN } },
-      );
-      if (result.status !== 0) process.exit(result.status ?? 1);
+      // Rewrite runtime imports in hermes package
+      if (pj.name === `${SCOPE_TO}hermes`) {
+        for (const rel of ["bin/install.mjs", "bridge/worker.mjs", "provider/__init__.py"]) {
+          try {
+            const fp = join(pkgDir, rel);
+            const orig = readFileSync(fp, "utf8");
+            const rewritten = rewriteScope(orig);
+            if (orig !== rewritten) writeFileSync(fp, rewritten);
+          } catch (err) {
+            if (err.code !== "ENOENT") console.warn(`Warning: failed to rewrite ${rel}: ${err.message}`);
+          }
+        }
+      }
+
+      run("npm", [
+        "publish", "./package",
+        "--registry", GHP_REGISTRY,
+        "--access", "public",
+        ...publishArgs,
+      ]);
     }
   } finally {
     rmSync(staging, { recursive: true, force: true });
   }
 }
 
-function publishToNpm({ publishArgs }) {
-  const args = buildArgs({ publishArgs, access: "public" });
-  for (const pkg of packages) {
-    const result = spawnSync("pnpm", ["--filter", pkg, ...args], { stdio: "inherit" });
-    if (result.status !== 0) process.exit(result.status ?? 1);
-  }
-}
-
 const { registry, publishArgs } = parseArgs();
-
-if (registry === "https://npm.pkg.github.com") {
-  await publishToGitHubPackages({ publishArgs });
+if (registry === GHP_REGISTRY) {
+  publishToGitHubPackages(publishArgs);
 } else {
-  publishToNpm({ publishArgs });
-}
+  publishToNpm(publishArgs);
+scripts/publish-npm.mjs}

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -43,7 +43,15 @@ function run(cmd, args) {
 
 function publishToNpm(publishArgs) {
   for (const pkg of TARGET_PACKAGES) {
-    run("pnpm", ["--filter", pkg, "publish", "--no-git-checks", "--access", "public", ...publishArgs]);
+    run("pnpm", [
+      "--filter",
+      pkg,
+      "publish",
+      "--no-git-checks",
+      "--access",
+      "public",
+      ...publishArgs,
+    ]);
   }
 }
 
@@ -85,15 +93,19 @@ function publishToGitHubPackages(publishArgs) {
             const rewritten = rewriteScope(orig);
             if (orig !== rewritten) writeFileSync(fp, rewritten);
           } catch (err) {
-            if (err.code !== "ENOENT") console.warn(`Warning: failed to rewrite ${rel}: ${err.message}`);
+            if (err.code !== "ENOENT")
+              console.warn(`Warning: failed to rewrite ${rel}: ${err.message}`);
           }
         }
       }
 
       run("npm", [
-        "publish", "./package",
-        "--registry", GHP_REGISTRY,
-        "--access", "public",
+        "publish",
+        "./package",
+        "--registry",
+        GHP_REGISTRY,
+        "--access",
+        "public",
         ...publishArgs,
       ]);
     }
@@ -107,4 +119,4 @@ if (registry === GHP_REGISTRY) {
   publishToGitHubPackages(publishArgs);
 } else {
   publishToNpm(publishArgs);
-scripts/publish-npm.mjs}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first contribution, read our CONTRIBUTING guide:
  https://github.com/iflytek/memflywheel/blob/main/CONTRIBUTING.md

-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Summary

  - Fix `preview-release` workflow: explicitly specify public package paths for `pkg-pr-new publish` to avoid `No packages` error when internal packages are
   marked `private: true`
  - Add GitHub Packages publishing to the release workflow, publishing under the `@iflytek/` scope so packages appear at `iflytek/memflywheel/packages`     
  - Refactor `scripts/publish-npm.mjs` to support dual-registry publishing via `--registry` flag:                                                           
    - **npm** (default): publishes `@iflytekopensource/adapters` and `@iflytekopensource/hermes`                                                            
    - **GitHub Packages**: rewrites scope from `@iflytekopensource/` → `@iflytek/` (including dependency references) before publishing                      
  - Add `.npmrc` to `.gitignore` to prevent accidental commit of temporary auth tokens 

## Checks

- [x] `pnpm run ci`
- [x] No old project names, private paths, credentials, or AI-signature footers
- [x] Package metadata still points to `iflytek/memflywheel`
- [x] Core does not call LLMs directly
- [x] Recall remains full-index, with no embedding/BM25/top-k/vector retrieval

## Special notes for reviewers

Publish public packages to both npm and GitHub Packages with dual-scope support
<!--
Please leave this section blank if you don't have any special notes.
-->
