### PR TITLE
Tighten learned skill generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ OpenClaw:
 
 ```sh
 openclaw plugins install npm:@iflytekopensource/adapters
+openclaw config set plugins.slots.memory memflywheel
 openclaw config set plugins.entries.memflywheel.hooks.allowConversationAccess true
 openclaw config set plugins.entries.memflywheel.hooks.allowPromptInjection true
 openclaw gateway run --force

--- a/README.zh.md
+++ b/README.zh.md
@@ -95,6 +95,7 @@ OpenClaw：
 
 ```sh
 openclaw plugins install npm:@iflytekopensource/adapters
+openclaw config set plugins.slots.memory memflywheel
 openclaw config set plugins.entries.memflywheel.hooks.allowConversationAccess true
 openclaw config set plugins.entries.memflywheel.hooks.allowPromptInjection true
 openclaw gateway run --force

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,19 @@ within `MAX_FRONTMATTER_LINES`, and `name` + a valid `type` are required or the 
 ignored. Supported memory types are `identity`, `preference`, `style`, `workflow`,
 `context`, and `ambient`.
 
+The built-in types are common defaults, not a closed product taxonomy. Host developers can
+add domain-specific categories if their adapter, scan rules, and prompt contract agree on the
+extra directories and `type` values.
+
+| Field             | Purpose                                                                |
+| ----------------- | ---------------------------------------------------------------------- |
+| `name`            | Short stable label shown in `MEMORY.md` and recall cues                |
+| `description`     | One-line routing summary, not the full memory body                     |
+| `type`            | Memory category and directory name                                     |
+| `retrieval_terms` | Short routing phrases for index-layer retrieval, not a body summary    |
+| Markdown body     | The actual memory content                                              |
+| `## Sources`      | Optional evidence refs into `.memflywheel/sources/*.jsonl` line ranges |
+
 Writes go through `writeMemoryDocument` / `deleteMemoryDocument` / `archiveMemoryDocument`
 on a `StorageContext` (`{ root, audit }`). Every write is:
 
@@ -91,6 +104,11 @@ model. Each entry becomes one line:
 through `truncateIndex` (≤ `INDEX_MAX_LINES` = 200 lines and ≤ `INDEX_MAX_BYTES` = 25 000
 UTF-8 bytes, with a truncation marker appended when cut) and `applyAgingHints` for
 time-sensitive memory types such as `context` and `ambient`.
+
+`retrieval_terms` help find the right index line; they should stay short and grounded in
+likely query wording. They are not a second description field and should not copy the memory
+body. Source traces are intentionally outside `MEMORY.md`: memory bodies may point to them
+through `## Sources`, but source JSONL is never scanned into the recall index.
 
 ## Recall
 
@@ -138,6 +156,18 @@ over the cleaned state: it reads full memory bodies and performs semantic consol
 returned anymore — the tool calls are the changes. `shouldRunDream` gates the pass on a
 minimum elapsed time (`DREAM_DEFAULT_MIN_HOURS` = 24) or a minimum session count
 (`DREAM_DEFAULT_MIN_SESSIONS` = 5).
+
+## Learned skills
+
+Learned skills use the same file-native rule: MemFlywheel stores and recalls them, while the
+host decides whether to load or execute them. Skill evolution writes into a staged checkpoint
+first. Finalize only publishes staged directories after validating package shape, path scope,
+and that the target skill tree was not externally changed; failures roll back to the snapshot.
+
+When skill evolution creates, updates, or merges a skill, the coordination result asks dream
+to compress redundant workflow memory into a cue pointing at the learned skill. That is the
+memory ↔ skill flywheel: repeated procedure details move out of ordinary memory and become a
+reusable skill route for future turns.
 
 ## Cross-cutting concerns
 

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,34 +1,52 @@
 # Evaluation
 
-MemFlywheel keeps evaluation lightweight in the public docs. The goal is to make
-long-term-memory behavior measurable without turning the repository docs into an
-experiment log.
+This page keeps benchmark and regression details out of the README.
 
-## Current Signal
+## LoCoMo Position
 
-The main benchmark signal is LoCoMo-style long-memory QA. It checks whether the
-Agent can use the file-native memory loop to answer questions through:
+On LoCoMo Cat1/2/4, MemFlywheel currently reports:
 
-| Layer      | What is measured                                                    |
-| ---------- | ------------------------------------------------------------------- |
-| Recall     | Whether relevant `MEMORY.md` cues are surfaced before the run       |
-| Reading    | Whether the Agent follows cues into memory bodies and source traces |
-| Extraction | Whether durable facts are written after a turn                      |
-| Learning   | Whether repeated workflows can become learned skills                |
+| Metric          |   Result | Setup                                                     |
+| --------------- | -------: | --------------------------------------------------------- |
+| LLM-judge score | `81.23%` | Local `bge-m3` embeddings, DeepSeek V4 Flash answer/judge |
+| Token-F1        | `65.93%` | Same run                                                  |
 
-## Local Regression
+Model choice matters because MemFlywheel is agent-driven. The same file-native
+memory store can score differently when the answer, judge, extraction, or recall
+model changes.
 
-For repository-level validation, use the normal CI command:
+## Public Comparison Context
+
+Only LoCoMo-related systems with a paper, official benchmark page, or official
+repository are listed here.
+
+| System                                                                                                                                                       |                                                             Public result | Source / practice                                                                          |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------: | ------------------------------------------------------------------------------------------ |
+| [LoCoMo](https://github.com/snap-research/locomo)                                                                                                            |                                                                 benchmark | Official ACL 2024 long-conversation memory benchmark                                       |
+| [Mem0](https://github.com/mem0ai/mem0) / [paper](https://arxiv.org/html/2504.19413v1)                                                                        |                                               67.13% paper / 92.5% latest | Multi-level memory, fact extraction, vector / graph retrieval                              |
+| [MemMachine](https://github.com/MemMachine/MemMachine) / [paper](https://arxiv.org/abs/2604.04853)                                                           |                                                                    91.69% | Full conversational episodes and contextualized retrieval                                  |
+| [Honcho](https://github.com/plastic-labs/honcho) / [eval](https://honcho.dev/evals/)                                                                         |                                                                     89.9% | Memory-agent service with user / agent / group modeling                                    |
+| **MemFlywheel current run**                                                                                                                                  | qwen/qwen3.7-plus: 87.12%; DeepSeek V4 Flash: 81.23%; GPT-4o-mini: 76.89% | File-native memory; Agent recalls through index, memory body, source trace, and tool calls |
+| [Memori](https://memorilabs.ai/docs/memori-cloud/benchmark/results/)                                                                                         |                                                                    81.95% | Semantic triples plus conversation summaries                                               |
+| [Zep / Graphiti](https://help.getzep.com/graphiti/getting-started/overview)                                                                                  |                                                             75.14%-80.00% | Temporal knowledge graph retrieval                                                         |
+| [Memobase](https://github.com/memodb-io/memobase) / [benchmark](https://github.com/memodb-io/memobase/blob/main/docs/experiments/locomo-benchmark/README.md) |                                                                    75.78% | User profile plus event timeline                                                           |
+| [Letta Filesystem](https://www.letta.com/blog/benchmarking-ai-agent-memory/)                                                                                 |                                                                    74.00% | Filesystem retrieval with search / grep / open                                             |
+| [LangMem](https://langchain-ai.github.io/langmem/)                                                                                                           |                                                             58.10%-78.05% | LangGraph BaseStore memories                                                               |
+| [MemoryOS](https://github.com/BAI-LAB/MemoryOS) / [paper](https://arxiv.org/html/2506.06326v1)                                                               |                                               F1 +49.11% / BLEU-1 +46.18% | Hierarchical short / mid / long-term memory                                                |
+| [A-Mem](https://github.com/agiresearch/A-mem) / [paper](https://arxiv.org/html/2502.12110v11)                                                                |                                                       LoCoMo F1 / ROUGE-L | Zettelkasten-style dynamic notes, tags, and linking                                        |
+| [SimpleMem](https://github.com/aiming-lab/SimpleMem) / [paper](https://arxiv.org/html/2601.02553v1)                                                          |                                                                  43.24 F1 | Structured compression plus query-aware retrieval                                          |
+
+## Local Regression Checks
+
+| Area       | What is checked                                                                                              |
+| ---------- | ------------------------------------------------------------------------------------------------------------ |
+| Extraction | Tool-calling subagent writes validated memories, preserves source refs, refuses private data when configured |
+| Dream      | Deterministic pre-pass plus consolidation runner keeps the store valid                                       |
+| Recall     | `MEMORY.md` rebuild, truncation, aging hints, index-layer retrieval, and prompt segments                     |
+| Skill loop | Staged skill changes are validated, finalized, rolled back, and routed into recall                           |
+
+Run the repository check before reporting results:
 
 ```sh
 pnpm run ci
 ```
-
-That covers lint, format, TypeScript build, unit tests, example smoke tests in
-GitHub Actions, and npm package dry-runs.
-
-## Benchmark Records
-
-Detailed experiment records, raw outputs, and local model artifacts are kept out
-of `docs/`. They belong under `bench/` or external experiment tracking, not in
-the public documentation surface.

--- a/docs/integrations.md
+++ b/docs/integrations.md
@@ -27,12 +27,12 @@ skill loops should fail fast instead of parsing free-form model text.
 
 ## Host Status
 
-| Host     | Status                       | Notes                                                                                        |
-| -------- | ---------------------------- | -------------------------------------------------------------------------------------------- |
-| Pi       | Implemented first-class path | Adapter, HarnessPort, lifecycle mapping, and canonical model mapping are implemented         |
-| Hermes   | Implemented plugin path      | MemoryProvider plugin uses Hermes' host-owned model/auth channel for write-side loops        |
-| OpenClaw | Planned/open target          | Memory injection is the likely first step; full write-side loop needs an OpenClaw model port |
-| OpenCode | Planned/open target          | Suitable for hook-native recall first; full loop needs host-owned tool-call model port       |
+| Host     | Status                       | Notes                                                                                    |
+| -------- | ---------------------------- | ---------------------------------------------------------------------------------------- |
+| Pi       | Implemented first-class path | Adapter, HarnessPort, lifecycle mapping, and canonical model mapping are implemented     |
+| Hermes   | Implemented plugin path      | MemoryProvider plugin uses Hermes' host-owned model/auth channel for write-side loops    |
+| OpenClaw | Implemented plugin path      | Load the adapter as OpenClaw's memory slot; hooks provide recall, extraction, and skills |
+| OpenCode | Implemented plugin path      | Load the adapter as an OpenCode plugin; hooks provide recall, extraction, and skills     |
 
 ## Pi Integration
 
@@ -196,6 +196,40 @@ pattern to confirm the full Hermes path:
 ```text
 Hermes main turn -> extraction -> skill evolution -> dream
 ```
+
+## OpenCode Integration
+
+```sh
+opencode plugin @iflytekopensource/adapters --global
+opencode run --dir /path/to/project "your task"
+```
+
+OpenCode keeps model configuration, tools, permissions, and sessions. The
+MemFlywheel plugin uses OpenCode hooks for prompt recall, turn-end extraction,
+source traces, skill evolution, and dream consolidation.
+
+For non-interactive `opencode run` tests, remember that OpenCode may reject file
+reads outside `--dir`. If the model needs to inspect
+`~/.config/opencode/memflywheel`, run interactively and approve the read, or use
+your test harness' explicit permission override.
+
+## OpenClaw Integration
+
+```sh
+openclaw plugins install npm:@iflytekopensource/adapters
+openclaw config set plugins.slots.memory memflywheel
+openclaw config set plugins.entries.memflywheel.hooks.allowConversationAccess true
+openclaw config set plugins.entries.memflywheel.hooks.allowPromptInjection true
+openclaw gateway run --force
+```
+
+The `plugins.slots.memory` setting is required because OpenClaw enables exactly
+one memory plugin slot. If the slot still points at `memory-core`, the
+MemFlywheel package is installed but inactive.
+
+After a real session, MemFlywheel files should appear under
+`~/.openclaw/memflywheel/`, including `MEMORY.md`, typed memory documents,
+source traces, and learned skills.
 
 ## Adapter Rules
 

--- a/packages/adapters/src/host-memflywheel.test.ts
+++ b/packages/adapters/src/host-memflywheel.test.ts
@@ -38,15 +38,27 @@ const STOP: CanonicalModelResponse = {
 const TARGET_SKILL = "memflywheel-learned-release-review";
 const VALID_SKILL = `---
 name: memflywheel-learned-release-review
-display_name: Release Review
-description: Captures a repeatable release preparation review.
+description: Use when release preparation repeats and the agent must avoid skipping package, CI, or hygiene checks.
 ---
 
-## Use Cases
+## Overview
 
-- Use when preparing a MemFlywheel package or repository release.
+Release review is a gate-driven skill for turning repeated release prep into a reusable checklist.
 
-## Procedure
+## When to Use
+
+- Use when the user asks to prepare, review, publish, or cut a release.
+- Do not use for ordinary feature work with no release action.
+
+## Quick Reference
+
+| Check | Stop Signal |
+|---|---|
+| Package metadata | Wrong repository, scope, or dependency target |
+| CI | Any failing lint, build, test, or pack dry-run |
+| Hygiene | Old names, private paths, credentials, or AI footers |
+
+## Steps
 
 1. Inspect package metadata, package files, and publish configuration.
 2. Inspect README, SECURITY, SUPPORT, CHANGELOG, and examples for release consistency.
@@ -54,10 +66,10 @@ description: Captures a repeatable release preparation review.
 4. Scan for old names, private paths, credentials, and AI-signature footers.
 5. Summarize release blockers before opening a pull request.
 
-## Guardrails
+## Common Mistakes
 
-- Do not publish when secrets, private paths, or old project names are present.
-- Keep release notes concise and evidence-based.
+- Treating a green build as release approval.
+- Writing local-only proxy or credential details into public release docs.
 `;
 
 function slug(name: string): string {
@@ -523,7 +535,8 @@ test("createMemFlywheelHarnessRuntime learnedSkills assembly runs extraction, sk
   assert.equal(result.learningLoop?.dream.ran, true);
 
   const skillFile = await readFile(path.join(skillsRoot, TARGET_SKILL, "SKILL.md"), "utf8");
-  assert.match(skillFile, /## Procedure/);
+  assert.match(skillFile, /## When to Use/);
+  assert.doesNotMatch(skillFile, /^display_name:/m);
   const memoryFile = await readFile(
     path.join(root, "memory", "workflow", "release-prep.md"),
     "utf8",

--- a/packages/sdk/src/skill-evolution-agent.ts
+++ b/packages/sdk/src/skill-evolution-agent.ts
@@ -34,27 +34,43 @@ Review the supplied packet, learned skill index, tool trajectory, artifact paths
 - If there is NO durable reusable method, change no files and stop. That is a valid no-op — do not invent a skill.
 - Change at most ONE surviving skill per pass (plus, for a merge, the directories you delete).
 
-# Skill directory + SKILL.md rules
+# Skill directory + SKILL.md quality rules
 
-- Every skill directory must be named memflywheel-learned-<slug> (lowercase slug). If the method's natural name is "release-runbook", use directory "memflywheel-learned-release-runbook".
-- "<skill-dir>/SKILL.md" must start with strict YAML frontmatter containing EXACTLY: name, display_name, description. The name value must equal the directory name (memflywheel-learned-<slug>).
-- SKILL.md must include the sections "## Use Cases", "## Procedure", and "## Guardrails". Procedure steps must be numbered "1.", "2.", ... contiguously, not bullets.
-- Optional supporting files may live under references/, scripts/, templates/, or assets/. They never replace SKILL.md.
+- Every skill directory must be named memflywheel-learned-<verb-first-slug> (lowercase slug). If the method's natural name is a noun phrase, prepend the concrete action verb. Example: "CLI adapter release checklist" becomes "memflywheel-learned-create-cli-adapter-release-checklist", NOT "memflywheel-learned-cli-adapter-release-checklist".
+- "<skill-dir>/SKILL.md" must start with strict YAML frontmatter containing EXACTLY: name and description. The name value must equal the directory name.
+- name is verb-first lowercase kebab-case after the memflywheel-learned- prefix. Use letters, digits, and hyphens only. Start the slug with a real action verb such as create, run, review, verify, debug, check, publish, migrate, or summarize.
+- description is the only discovery surface: start with "Use when ..." and write trigger conditions, symptoms, and red flags. Do NOT summarize the workflow or list steps there.
+- Frontmatter must stay under 1024 characters; keep description under 500 characters when possible.
+- Body sections are chosen by content, not filled by habit: use ## Overview for one sentence, ## When to Use for triggers and when not to use, ## Quick Reference for multi-item reference, numbered lists for linear steps, a small ASCII flow for non-obvious decisions, before/after for comparisons, and ## Common Mistakes only for real non-obvious traps.
+- Mechanical checks belong in scripts/, not long pass/fail prose. Reference tables belong in the body. Optional supporting files may live under references/, scripts/, templates/, or assets/. They never replace SKILL.md.
 - Keep names generic; never leak host project names or secrets into a learned skill.
+- Reject the five fatal shapes: description explains procedure; body is only happy-path steps; pass/fail assertions replace a script; project-specific values pretend to be general; invented sections or fake pitfalls.
 
 # Valid SKILL.md shape
 
 ---
-name: memflywheel-learned-release-runbook
-display_name: Release Runbook
-description: Reusable procedure for safely running a release.
+name: memflywheel-learned-run-release
+description: Use when a release, publish, version cut, or npm tag push is requested and the agent must avoid skipping repo gates under time pressure.
 ---
 
-## Use Cases
+## Overview
 
-- Run this when the user asks to publish, release, or cut a version.
+Release work is a gate-driven workflow: prove the repo is clean enough before any remote write.
 
-## Procedure
+## When to Use
+
+- Use when the request mentions release, publish, npm, version bump, dist-tag, or pushing a release tag.
+- Do not use for ordinary feature PRs with no release action.
+
+## Quick Reference
+
+| Check | Stop Signal |
+|---|---|
+| CI | Any failing lint, build, test, or pack dry-run |
+| Secrets | Credentials, private paths, or local-only files in package output |
+| Remote write | User has not explicitly confirmed target and action |
+
+## Steps
 
 1. Build the workspace and stop on failure.
 2. Run the full test suite and stop on failure.
@@ -62,24 +78,36 @@ description: Reusable procedure for safely running a release.
 4. Publish using the approved package command.
 5. Create and push the release tag.
 
-## Guardrails
+## Common Mistakes
 
-- Do not publish when build or tests fail.
-- Do not write secrets or private credentials into files.
+- Treating a green local build as permission to push a tag.
+- Writing local proxy or credential details into public release notes.
 
 When your file edits are complete, stop calling tools. You do not need to emit any JSON, summary, or skill coordination.`;
 
 export const LEARNED_SKILL_MD_TEMPLATE = `---
-name: memflywheel-learned-release-runbook
-display_name: Release Runbook
-description: Reusable procedure for safely running a release.
+name: memflywheel-learned-run-release
+description: Use when a release, publish, version cut, or npm tag push is requested and the agent must avoid skipping repo gates under time pressure.
 ---
 
-## Use Cases
+## Overview
 
-- Run this when the user asks to publish, release, or cut a version.
+Release work is a gate-driven workflow: prove the repo is clean enough before any remote write.
 
-## Procedure
+## When to Use
+
+- Use when the request mentions release, publish, npm, version bump, dist-tag, or pushing a release tag.
+- Do not use for ordinary feature PRs with no release action.
+
+## Quick Reference
+
+| Check | Stop Signal |
+|---|---|
+| CI | Any failing lint, build, test, or pack dry-run |
+| Secrets | Credentials, private paths, or local-only files in package output |
+| Remote write | User has not explicitly confirmed target and action |
+
+## Steps
 
 1. Build the workspace and stop on failure.
 2. Run the full test suite and stop on failure.
@@ -87,10 +115,10 @@ description: Reusable procedure for safely running a release.
 4. Publish using the approved package command.
 5. Create and push the release tag.
 
-## Guardrails
+## Common Mistakes
 
-- Do not publish when build or tests fail.
-- Do not write secrets or private credentials into files.
+- Treating a green local build as permission to push a tag.
+- Writing local proxy or credential details into public release notes.
 `;
 
 export type SkillEvolutionDecision = "create" | "update" | "merge" | "noop";

--- a/packages/skills/README.md
+++ b/packages/skills/README.md
@@ -17,14 +17,15 @@ A learned skill is a directory named `memflywheel-learned-<slug>` that contains:
 
 ```yaml
 ---
-name: memflywheel-learned-example
-display_name: Example
-description: Captures a durable workflow.
+name: memflywheel-learned-review-release
+description: Use when release review repeats and the agent must avoid skipping package, CI, or hygiene checks.
 ---
 ```
 
-The body must include `## Use Cases`, `## Procedure`, and `## Guardrails`.
-`## Procedure` must contain contiguous numbered steps starting at `1.`.
+The description is the discovery surface: write when to use the skill, not the
+procedure. Body shape follows the content: use `## When to Use` for triggers,
+tables for reference, numbered lists for linear steps, small ASCII flows for
+non-obvious decisions, and scripts for mechanical checks.
 
 ## API
 
@@ -68,7 +69,7 @@ Prompt recall is routing-only:
 ```text
 createLearnedSkillRecallProvider()
   -> validates learned skill directories
-  -> returns name / display name / description / path / trigger hints
+  -> returns name / derived display name / description / path / trigger hints
   -> does not execute skills or copy procedure steps into memory
 ```
 

--- a/packages/skills/src/learned-skill.test.ts
+++ b/packages/skills/src/learned-skill.test.ts
@@ -21,43 +21,51 @@ import {
 
 const validSkill = `---
 name: memflywheel-learned-editor-workflow
-display_name: Editor Workflow
-description: Captures durable editor workflow habits.
+description: Use when repeated editor workflow habits appear and need a reusable trigger-based skill instead of another memory note.
 ---
 
-## Use Cases
+## Overview
 
-- Preserve repeatable editor workflow choices.
+Editor workflow skills preserve reusable editing judgment, not one-off notes.
 
-## Procedure
+## When to Use
+
+- Use when the user repeats the same editor workflow or shortcut sequence.
+- Do not use for a one-time editing preference.
+
+## Steps
 
 1. Inspect the current workflow evidence.
 2. Record the durable rule and its trigger.
 
-## Guardrails
+## Common Mistakes
 
-- Keep host-specific details out of public skill text.
+- Writing the whole successful transcript instead of the reusable trigger.
 `;
 
-function skillContent(skillName: string, displayName: string, description: string): string {
+function skillContent(skillName: string, description: string): string {
   return `---
 name: ${skillName}
-display_name: ${displayName}
 description: ${description}
 ---
 
-## Use Cases
+## Overview
 
-- Preserve repeatable editor workflow choices.
+Editor workflow skills preserve reusable editing judgment, not one-off notes.
 
-## Procedure
+## When to Use
+
+- Use when the user repeats the same editor workflow or shortcut sequence.
+- Do not use for a one-time editing preference.
+
+## Steps
 
 1. Inspect the current workflow evidence.
 2. Record the durable rule and its trigger.
 
-## Guardrails
+## Common Mistakes
 
-- Keep host-specific details out of public skill text.
+- Writing the whole successful transcript instead of the reusable trigger.
 `;
 }
 
@@ -101,8 +109,8 @@ test("validateLearnedSkillPackage accepts the MemFlywheel learned skill layout",
   ]);
 
   const skillWithType = validSkill.replace(
-    "description: Captures durable editor workflow habits.\n",
-    "type: skill\ndescription: Captures durable editor workflow habits.\n",
+    "description: Use when repeated editor workflow habits appear and need a reusable trigger-based skill instead of another memory note.\n",
+    "type: skill\ndescription: Use when repeated editor workflow habits appear and need a reusable trigger-based skill instead of another memory note.\n",
   );
   const withType = validateLearnedSkillPackage({
     slug: "editor-workflow",
@@ -113,8 +121,8 @@ test("validateLearnedSkillPackage accepts the MemFlywheel learned skill layout",
 
 test("validateLearnedSkillPackage accepts loose skill markdown", () => {
   const extraFrontmatterKey = validSkill.replace(
-    "description: Captures durable editor workflow habits.\n",
-    "description: Captures durable editor workflow habits.\nversion: 1\n",
+    "description: Use when repeated editor workflow habits appear and need a reusable trigger-based skill instead of another memory note.\n",
+    "description: Use when repeated editor workflow habits appear and need a reusable trigger-based skill instead of another memory note.\nversion: 1\n",
   );
   assert.equal(
     validateLearnedSkillPackage({
@@ -125,15 +133,15 @@ test("validateLearnedSkillPackage accepts loose skill markdown", () => {
   );
 
   const invalidType = validSkill.replace(
-    "description: Captures durable editor workflow habits.\n",
-    "type: workflow\ndescription: Captures durable editor workflow habits.\n",
+    "description: Use when repeated editor workflow habits appear and need a reusable trigger-based skill instead of another memory note.\n",
+    "type: workflow\ndescription: Use when repeated editor workflow habits appear and need a reusable trigger-based skill instead of another memory note.\n",
   );
   assert.equal(
     validateLearnedSkillPackage({
       slug: "editor-workflow",
       files: { ...validFiles(), "SKILL.md": invalidType },
     }).frontmatter.description,
-    "Captures durable editor workflow habits.",
+    "Use when repeated editor workflow habits appear and need a reusable trigger-based skill instead of another memory note.",
   );
 
   const unnumberedProcedure = validSkill.replace(
@@ -156,7 +164,6 @@ test("validateLearnedSkillPackage accepts loose skill markdown", () => {
     }).frontmatter,
     {
       name: `${LEARNED_SKILL_DIR_PREFIX}editor-workflow`,
-      display_name: "Editor Workflow",
       description: "Learned skill.",
     },
   );
@@ -197,7 +204,7 @@ test("validateLearnedSkillPackage rejects invalid supporting files and configure
       error.message.includes("exceeds 1048576 bytes"),
   );
 
-  const leakedName = validSkill.replace("durable editor workflow", "LegacyHost editor workflow");
+  const leakedName = validSkill.replace("editor workflow habits", "LegacyHost workflow habits");
   assert.throws(
     () =>
       validateLearnedSkillPackage({
@@ -334,7 +341,7 @@ test("rollbackLearnedSkillCheckpoint restores a full target snapshot", async () 
     await writeRaw(
       skillsRoot,
       "memflywheel-learned-editor-workflow/SKILL.md",
-      validSkill.replace("durable editor", "original editor"),
+      validSkill.replace("reusable editing judgment", "original editor judgment"),
     );
     await writeRaw(skillsRoot, "memflywheel-learned-editor-workflow/assets/kept.txt", "keep me\n");
 
@@ -352,7 +359,7 @@ test("rollbackLearnedSkillCheckpoint restores a full target snapshot", async () 
       path.join(skillsRoot, "memflywheel-learned-editor-workflow", "SKILL.md"),
       "utf8",
     );
-    assert.match(restoredSkill, /original editor/);
+    assert.match(restoredSkill, /original editor judgment/);
     assert.equal(
       await readFile(
         path.join(skillsRoot, "memflywheel-learned-editor-workflow", "assets", "kept.txt"),
@@ -398,12 +405,12 @@ test("createLearnedSkillStore commits staged tool writes and can rollback after 
       path.join(skillsRoot, "memflywheel-learned-editor-workflow", "SKILL.md"),
       "utf8",
     );
-    assert.match(publishedSkill, /^type: skill$/m);
+    assert.doesNotMatch(publishedSkill, /^type: skill$/m);
 
     const catalog = await store.getLearnedSkillsCatalog({ includeContent: true });
     assert.equal(catalog.learnedSkills.length, 1);
     assert.equal(catalog.learnedSkills[0]?.name, "memflywheel-learned-editor-workflow");
-    assert.match(catalog.learnedSkills[0]?.skillContent ?? "", /## Procedure/);
+    assert.match(catalog.learnedSkills[0]?.skillContent ?? "", /## When to Use/);
 
     await store.rollbackSkillCheckpoint(checkpoint);
     const emptyCatalog = await store.getLearnedSkillsCatalog();
@@ -423,12 +430,12 @@ test("createLearnedSkillStore can merge by updating one skill and archiving a du
     await writeRaw(
       skillsRoot,
       `${target}/SKILL.md`,
-      skillContent(target, "Editor Workflow", "Captures durable editor workflow habits."),
+      skillContent(target, "Use when repeated editor workflow habits appear."),
     );
     await writeRaw(
       skillsRoot,
       `${duplicate}/SKILL.md`,
-      skillContent(duplicate, "Editor Shortcuts", "Captures duplicate editor workflow shortcuts."),
+      skillContent(duplicate, "Use when duplicate editor workflow shortcuts appear."),
     );
 
     const store = createLearnedSkillStore({ skillsRoot, checkpointRoot });
@@ -437,11 +444,7 @@ test("createLearnedSkillStore can merge by updating one skill and archiving a du
 
     await tools.get("write")!.handler({
       filePath: `${target}/SKILL.md`,
-      content: skillContent(
-        target,
-        "Editor Workflow",
-        "Merged editor workflow and shortcut procedure.",
-      ),
+      content: skillContent(target, "Use when editor workflow and shortcut procedures overlap."),
     });
     await tools.get("bash")!.handler({
       command: `rm -rf ${duplicate}`,
@@ -466,7 +469,10 @@ test("createLearnedSkillStore can merge by updating one skill and archiving a du
       catalog.learnedSkills.map((skill) => skill.name),
       [target],
     );
-    assert.match(catalog.learnedSkills[0]?.skillContent ?? "", /Merged editor workflow/);
+    assert.match(
+      catalog.learnedSkills[0]?.skillContent ?? "",
+      /Use when editor workflow and shortcut procedures overlap/,
+    );
 
     await store.rollbackSkillCheckpoint(checkpoint);
     const restored = await store.getLearnedSkillsCatalog();
@@ -495,10 +501,7 @@ test("createLearnedSkillRecallProvider exposes learned skill routes for prompt b
 
     assert.equal(packet.entries.length, 1);
     assert.equal(packet.entries[0]?.name, "memflywheel-learned-editor-workflow");
-    assert.deepEqual(packet.entries[0]?.triggerHints, [
-      "editor workflow",
-      "durable editor workflow",
-    ]);
+    assert.deepEqual(packet.entries[0]?.triggerHints, ["editor workflow"]);
     assert.equal(
       packet.entries[0]?.relativePath,
       path.join(skillsRoot, "memflywheel-learned-editor-workflow", "SKILL.md"),

--- a/packages/skills/src/learned-skill.ts
+++ b/packages/skills/src/learned-skill.ts
@@ -62,7 +62,6 @@ export interface ValidateLearnedSkillPackageInput {
 
 export interface LearnedSkillFrontmatter {
   name: string;
-  display_name: string;
   description: string;
 }
 
@@ -435,7 +434,7 @@ export async function getLearnedSkillsCatalog(input: {
       : undefined;
     learnedSkills.push({
       name: validated.skillName,
-      displayName: validated.frontmatter.display_name,
+      displayName: titleizeSlug(validated.skillName),
       description: validated.frontmatter.description,
       relativePath: `${validated.skillDir}/SKILL.md`,
       supportingFiles: supportingFilesFromValidated(validated),
@@ -583,27 +582,6 @@ function createLearnedSkillFileTools(input: {
   return createCoreFileTools().map((tool) => bindStageFileTool(tool, input.checkpoint));
 }
 
-function withDefaultSkillType(content: string): string {
-  const lines = content.split("\n");
-  if (lines[0] !== "---") return content;
-  const endIndex = lines.indexOf("---", 1);
-  if (endIndex === -1) return content;
-  if (lines.slice(1, endIndex).some((line) => /^type\s*:/u.test(line))) return content;
-  return [...lines.slice(0, endIndex), "type: skill", ...lines.slice(endIndex)].join("\n");
-}
-
-async function addDefaultSkillType(
-  stageRoot: string,
-  skillNames: readonly string[],
-): Promise<void> {
-  for (const skillName of skillNames) {
-    const skillPath = path.join(stageRoot, skillName, "SKILL.md");
-    const content = await readFile(skillPath, "utf8");
-    const next = withDefaultSkillType(content);
-    if (next !== content) await writeFile(skillPath, next, "utf8");
-  }
-}
-
 /** A token that begins with "/" — i.e. an absolute filesystem path. */
 function commandUsesAbsolutePath(command: string): boolean {
   return /(?:^|[\s"'`=(<>|;&])\/[^\s/]/.test(command);
@@ -690,18 +668,6 @@ async function finalizeLearnedSkillStoreCheckpoint(input: {
 
   let changedFiles = [...stagedDiff.changedPaths, ...stagedDiff.deletedPaths].sort();
   let changedSkillNames = [
-    ...new Set(changedFiles.map((relativePath) => relativePath.split("/")[0] ?? "")),
-  ]
-    .filter(Boolean)
-    .sort();
-  await addDefaultSkillType(
-    manifest.stageRoot,
-    changedSkillNames.filter((skillName) => !deletedSkillNames.includes(skillName)),
-  );
-  stagedFiles = await listFileFingerprints(manifest.stageRoot);
-  stagedDiff = diffFingerprints(manifest.beforeFiles, stagedFiles);
-  changedFiles = [...stagedDiff.changedPaths, ...stagedDiff.deletedPaths].sort();
-  changedSkillNames = [
     ...new Set(changedFiles.map((relativePath) => relativePath.split("/")[0] ?? "")),
   ]
     .filter(Boolean)
@@ -1078,10 +1044,8 @@ function titleizeSlug(skillName: string): string {
 }
 
 function parseSkillFrontmatter(content: string, expectedName: string): LearnedSkillFrontmatter {
-  const fallbackDisplayName = titleizeSlug(expectedName);
   const fallback = {
     name: expectedName,
-    display_name: fallbackDisplayName || expectedName,
     description: "Learned skill.",
   };
   const lines = content.split("\n");
@@ -1105,7 +1069,6 @@ function parseSkillFrontmatter(content: string, expectedName: string): LearnedSk
 
   return {
     name: meta.get("name") || fallback.name,
-    display_name: meta.get("display_name") || meta.get("name") || fallback.display_name,
     description: meta.get("description") || fallback.description,
   };
 }


### PR DESCRIPTION
## Summary

- tighten learned-skill generation rules around verb-first names, trigger-only descriptions, and content-shaped bodies
- remove automatic `type: skill` insertion from learned-skill finalization and derive display names from skill names
- refresh host integration docs, evaluation notes, and learned-skill regression tests for the stricter package shape

## Validation

- `git diff --check upstream/main...HEAD`
- `pnpm run build && pnpm run test`
- `pnpm run pack:dry-run`
- local end-to-end verification across Pi, Hermes, OpenCode, and OpenClaw for extraction, learned-skill creation, and fresh-session recall
