### PR TITLE
fix(ci): resolve GitHub Packages publish failures

### DIFF
--- a/packages/hermes-plugin/package.json
+++ b/packages/hermes-plugin/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "type": "module",
   "bin": {
-    "memflywheel-hermes-install": "./bin/install.mjs"
+    "memflywheel-hermes-install": "bin/install.mjs"
   },
   "files": [
     "LICENSE",

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -101,7 +101,7 @@ function publishToGitHubPackages(publishArgs) {
 
       run("npm", [
         "publish",
-        "./package",
+        pkgDir,
         "--registry",
         GHP_REGISTRY,
         "--access",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first contribution, read our CONTRIBUTING guide:
  https://github.com/iflytek/memflywheel/blob/main/CONTRIBUTING.md

-->

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->

## Summary                                                                                                                                           
                                                                                                                                                         
  This PR fixes critical CI failures in the GitHub Packages publishing workflow and improves the dual-registry publishing infrastructure. 

ref: https://github.com/iflytek/memflywheel/actions/runs/28564764650/job/84689660403

## Checks

- [x] `pnpm run ci`
- [x] No old project names, private paths, credentials, or AI-signature footers
- [x] Package metadata still points to `iflytek/memflywheel`
- [x] Core does not call LLMs directly
- [x] Recall remains full-index, with no embedding/BM25/top-k/vector retrieval

## Special notes for reviewers

None
<!--
Please leave this section blank if you don't have any special notes.
-->
