### PR TITLE
feat(e2e): add OpenClaw agent to K8s E2E test framework

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -64,12 +64,14 @@ jobs:
           docker build -t mock-llm:e2e -f e2e/mock-llm/Dockerfile e2e/mock-llm/
           docker build -t hermes-memflywheel:e2e -f e2e/kind/Dockerfile.hermes .
           docker build -t pi-memflywheel:e2e -f e2e/kind/Dockerfile.pi .
+          docker build -t openclaw-memflywheel:e2e -f e2e/kind/Dockerfile.openclaw .
 
       - name: Load images into kind
         run: |
           kind load docker-image mock-llm:e2e --name memflywheel-e2e
           kind load docker-image hermes-memflywheel:e2e --name memflywheel-e2e
           kind load docker-image pi-memflywheel:e2e --name memflywheel-e2e
+          kind load docker-image openclaw-memflywheel:e2e --name memflywheel-e2e
 
       - name: Deploy mock LLM
         run: |
@@ -87,6 +89,13 @@ jobs:
           kubectl apply -n pi-test -f e2e/kind/pi-sandbox.yaml
           kubectl wait --for=condition=Ready sandbox/pi-agent \
             -n pi-test --timeout=180s
+
+      - name: Deploy OpenClaw Sandbox
+        run: |
+          kubectl apply -n openclaw-test -f e2e/kind/openclaw-config.yaml
+          kubectl apply -n openclaw-test -f e2e/kind/openclaw-sandbox.yaml
+          kubectl wait --for=condition=Ready sandbox/openclaw-agent \
+            -n openclaw-test --timeout=180s
 
       - name: Debug — cluster state
         if: always()
@@ -108,6 +117,8 @@ jobs:
           kubectl logs -n hermes-test pod/hermes-agent --tail=100 2>/dev/null || true
           echo "=== Pi pod logs ==="
           kubectl logs -n pi-test pod/pi-agent --tail=100 2>/dev/null || true
+          echo "=== OpenClaw pod logs ==="
+          kubectl logs -n openclaw-test pod/openclaw-agent --tail=100 2>/dev/null || true
           echo "=== Mock LLM logs ==="
           kubectl logs -l app=mock-llm --tail=50 2>/dev/null || true
 

--- a/e2e/agents.mjs
+++ b/e2e/agents.mjs
@@ -135,6 +135,58 @@ async function piAfterTurns(testCase) {
   await delay(2000);
 }
 
+// ─── OpenClaw ───────────────────────────────────────────────────────────────
+
+const OPENCLAW_NS = "openclaw-test";
+const OPENCLAW_POD = "openclaw-agent";
+const OPENCLAW_WORKSPACE = "/home/node/.openclaw/workspace";
+const OPENCLAW_MEMORY_ROOT = "/home/node/.openclaw/memflywheel";
+
+function openclawChat(prompt) {
+  return kubectlExec(OPENCLAW_NS, OPENCLAW_POD, "node", "/e2e/openclaw/chat.mjs", prompt);
+}
+
+function openclawVerifySetup() {
+  try {
+    const nodeVersion = kubectlExec(OPENCLAW_NS, OPENCLAW_POD, "node", "--version");
+    check("node binary available", Boolean(nodeVersion), nodeVersion?.slice(0, 50));
+  } catch (e) {
+    check("node binary available", false, e.message?.slice(0, 100));
+  }
+  try {
+    const adapterList = kubectlExec(
+      OPENCLAW_NS,
+      OPENCLAW_POD,
+      "ls",
+      "/usr/local/lib/node_modules/@iflytekopensource/",
+    );
+    check("adapters package installed", adapterList.includes("adapters"));
+  } catch {
+    check("adapters package installed", false, "node_modules not found");
+  }
+  try {
+    const scripts = kubectlExec(OPENCLAW_NS, OPENCLAW_POD, "ls", "/e2e/openclaw/");
+    check("chat.mjs present", scripts.includes("chat.mjs"));
+    check("extract.mjs present", scripts.includes("extract.mjs"));
+  } catch {
+    check("chat.mjs present", false, "e2e scripts not found");
+    check("extract.mjs present", false);
+  }
+}
+
+async function openclawAfterTurns(testCase) {
+  const prompts = testCase.prompts.map((p) => p.text);
+  kubectlExec(
+    OPENCLAW_NS,
+    OPENCLAW_POD,
+    "node",
+    "/e2e/openclaw/extract.mjs",
+    OPENCLAW_WORKSPACE,
+    ...prompts,
+  );
+  await delay(2000);
+}
+
 // ─── exports ───────────────────────────────────────────────────────────────
 
 export const AGENTS = [
@@ -165,5 +217,17 @@ export const AGENTS = [
     ],
     memoryDirs: ["/root/.memflywheel", "/workspace", "/root/.pi/agent/memflywheel"],
     debugDir: "/workspace",
+  },
+  {
+    name: "OpenClaw",
+    namespace: OPENCLAW_NS,
+    sandbox: OPENCLAW_POD,
+    chatFn: openclawChat,
+    waitForSetup: null,
+    verifySetup: openclawVerifySetup,
+    afterTurns: openclawAfterTurns,
+    memoryPaths: [`${OPENCLAW_MEMORY_ROOT}/MEMORY.md`, `${OPENCLAW_WORKSPACE}/MEMORY.md`],
+    memoryDirs: [OPENCLAW_MEMORY_ROOT, OPENCLAW_WORKSPACE],
+    debugDir: OPENCLAW_MEMORY_ROOT,
   },
 ];

--- a/e2e/kind/Dockerfile.openclaw
+++ b/e2e/kind/Dockerfile.openclaw
@@ -1,0 +1,32 @@
+# OpenClaw agent image with memflywheel adapter baked in.
+#
+# Build context: repo root.
+# Expected files in build context:
+#   e2e/packages/iflytekopensource-adapters-*.tgz
+#   e2e/openclaw/chat.mjs
+#   e2e/openclaw/extract.mjs
+
+FROM ghcr.io/openclaw/openclaw:2026.3.23
+
+USER root
+
+# Copy memflywheel adapter package
+COPY e2e/packages/iflytekopensource-adapters-*.tgz /tmp/adapters.tgz
+RUN npm install -g /tmp/adapters.tgz
+
+# Make globally-installed packages resolvable from any working directory
+ENV NODE_PATH=/usr/local/lib/node_modules
+
+# Copy memflywheel e2e scripts
+RUN mkdir -p /e2e/openclaw
+COPY e2e/openclaw/chat.mjs /e2e/openclaw/chat.mjs
+COPY e2e/openclaw/extract.mjs /e2e/openclaw/extract.mjs
+# Node.js ESM import does NOT respect NODE_PATH — symlink global node_modules
+RUN ln -sf /usr/local/lib/node_modules /e2e/openclaw/node_modules
+
+# Point OpenClaw LLM at the mock service
+ENV OPENAI_API_KEY=mock-key
+ENV OPENAI_BASE_URL=http://mock-llm.default.svc.cluster.local:8080/v1
+
+USER 1000
+CMD ["tail", "-f", "/dev/null"]

--- a/e2e/kind/openclaw-config.yaml
+++ b/e2e/kind/openclaw-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openclaw-config
+data:
+  openclaw.json: |
+    {
+      "gateway": {
+        "controlUi": {
+          "dangerouslyAllowHostHeaderOriginFallback": true
+        }
+      }
+    }

--- a/e2e/kind/openclaw-sandbox.yaml
+++ b/e2e/kind/openclaw-sandbox.yaml
@@ -1,0 +1,65 @@
+apiVersion: agents.x-k8s.io/v1beta1
+kind: Sandbox
+metadata:
+  name: openclaw-agent
+spec:
+  podTemplate:
+    metadata:
+      labels:
+        sandbox: openclaw-agent
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: openclaw
+          image: openclaw-memflywheel:e2e
+          imagePullPolicy: Never
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          env:
+            - name: OPENCLAW_GATEWAY_TOKEN
+              value: "e2e-test-token"
+            - name: OPENCLAW_CONFIG_PATH
+              value: "/etc/openclaw/openclaw.json"
+          command:
+            - node
+            - dist/index.js
+            - gateway
+            - --bind=lan
+            - --port
+            - "18789"
+            - --allow-unconfigured
+            - --verbose
+          ports:
+            - containerPort: 18789
+            - containerPort: 18790
+          volumeMounts:
+            - mountPath: /home/node/.openclaw/workspace
+              name: workspaces-pvc
+            - mountPath: /home/node/.openclaw
+              name: config-volume
+            - mountPath: /etc/openclaw
+              name: cm-volume
+      volumes:
+        - name: config-volume
+          emptyDir: {}
+        - name: cm-volume
+          configMap:
+            name: openclaw-config
+  volumeClaimTemplates:
+    - metadata:
+        name: workspaces-pvc
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Gi

--- a/e2e/kind/setup.sh
+++ b/e2e/kind/setup.sh
@@ -19,6 +19,7 @@ kubectl wait --for=condition=Ready pod -l app=agent-sandbox-controller \
 echo "==> Creating test namespaces"
 kubectl create namespace hermes-test --dry-run=client -o yaml | kubectl apply -f -
 kubectl create namespace pi-test --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace openclaw-test --dry-run=client -o yaml | kubectl apply -f -
 
 echo "==> Setup complete"
 kubectl get pods -A

--- a/e2e/openclaw/chat.mjs
+++ b/e2e/openclaw/chat.mjs
@@ -1,0 +1,83 @@
+/**
+ * OpenClaw chat simulator for K8s e2e test.
+ *
+ * OpenClaw runs as a gateway; its plugin API exposes hooks but not a direct
+ * model-call interface. This script simulates an OpenClaw session by:
+ *   1. Creating a mock OpenClaw host (event emitter)
+ *   2. Loading the memflywheel adapter + runtime
+ *   3. Emitting lifecycle events (before_agent_start, context:inject, agent_end, idle:watch)
+ *   4. The runtime handles recall and records the turn for later extraction
+ *
+ * Usage: node /e2e/openclaw/chat.mjs "prompt text"
+ */
+
+import { createMemFlywheelHarnessRuntime, openclawAdapter } from "@iflytekopensource/adapters";
+
+const prompt = process.argv[2];
+if (!prompt) {
+  console.error("Usage: node chat.mjs <prompt>");
+  process.exit(1);
+}
+
+const root = process.env.MEMFLYWHEEL_ROOT || "/home/node/.openclaw/memflywheel";
+
+// ─── mock OpenClaw host (event emitter) ────────────────────────────────────
+
+const listeners = new Map();
+
+const host = {
+  on(event, fn) {
+    const set = listeners.get(event) ?? new Set();
+    set.add(fn);
+    listeners.set(event, set);
+    return () => set.delete(fn);
+  },
+  emit(event, payload) {
+    for (const fn of listeners.get(event) ?? []) fn(payload);
+  },
+  registerMemoryCapability(cap) {
+    host._memoryCapability = cap;
+  },
+};
+
+// ─── load memflywheel runtime ──────────────────────────────────────────────
+
+const { scribe } = createMemFlywheelHarnessRuntime({ mode: "recall-only", root });
+openclawAdapter.attach(scribe, host);
+
+// ─── simulate lifecycle ────────────────────────────────────────────────────
+
+// Session start
+host.emit("before_agent_start", { agentId: "e2e" });
+
+// Prompt build — get memory context (recall)
+let memoryContext;
+host.emit("context:inject", {
+  agentId: "e2e",
+  respond: (p) => {
+    memoryContext = p;
+  },
+});
+
+// Forward turn to memflywheel (transcript recording)
+host.emit("agent_end", {
+  agentId: "e2e",
+  messages: [
+    { role: "user", content: prompt },
+    { role: "assistant", content: "Got it! I'll remember that for next time." },
+  ],
+});
+
+// Flush / idle
+host.emit("idle:watch", {});
+
+// Wait a moment for async operations
+await new Promise((r) => setTimeout(r, 1000));
+
+console.log(
+  JSON.stringify({
+    ok: true,
+    hasMemoryContext: Boolean(memoryContext?.preludePrompt),
+    prompt: prompt.slice(0, 60),
+  }),
+);

--- a/e2e/openclaw/extract.mjs
+++ b/e2e/openclaw/extract.mjs
@@ -1,0 +1,266 @@
+/**
+ * Standalone memflywheel extraction script for OpenClaw K8s E2E test.
+ *
+ * OpenClaw's plugin API does not expose a direct model-call interface,
+ * so extraction cannot run natively inside the gateway. This script
+ * provides a standalone extraction step that:
+ *   1. Takes conversation prompts from CLI args
+ *   2. Sends each to mock-llm with file tools (the extraction agent flow)
+ *   3. Executes tool calls (glob, write) to create memory files
+ *   4. Builds MEMORY.md index from extracted files
+ *
+ * Usage: node /e2e/openclaw/extract.mjs <workspace-dir> [prompt1] [prompt2] ...
+ */
+
+import { readdir, readFile, writeFile, mkdir } from "node:fs/promises";
+import { join } from "node:path";
+
+const MOCK_LLM_URL = "http://mock-llm.default.svc.cluster.local:8080/v1/chat/completions";
+
+const FILE_TOOLS = [
+  {
+    type: "function",
+    function: {
+      name: "read",
+      description: "Read a file",
+      parameters: {
+        type: "object",
+        properties: { filePath: { type: "string" } },
+        required: ["filePath"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "write",
+      description: "Write a file",
+      parameters: {
+        type: "object",
+        properties: { filePath: { type: "string" }, content: { type: "string" } },
+        required: ["filePath", "content"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "edit",
+      description: "Edit a file",
+      parameters: {
+        type: "object",
+        properties: {
+          filePath: { type: "string" },
+          oldText: { type: "string" },
+          newText: { type: "string" },
+        },
+        required: ["filePath"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "bash",
+      description: "Run a bash command",
+      parameters: {
+        type: "object",
+        properties: { command: { type: "string" } },
+        required: ["command"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "glob",
+      description: "Find files matching a pattern",
+      parameters: {
+        type: "object",
+        properties: { pattern: { type: "string" } },
+        required: ["pattern"],
+      },
+    },
+  },
+  {
+    type: "function",
+    function: {
+      name: "grep",
+      description: "Search file contents",
+      parameters: {
+        type: "object",
+        properties: { pattern: { type: "string" }, path: { type: "string" } },
+        required: ["pattern"],
+      },
+    },
+  },
+];
+
+async function chat(messages) {
+  const body = {
+    model: "mock-llm",
+    stream: false,
+    messages,
+    tools: FILE_TOOLS,
+  };
+  const res = await fetch(MOCK_LLM_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Authorization: "Bearer mock-key" },
+    body: JSON.stringify(body),
+  });
+  return res.json();
+}
+
+async function executeTool(call, workspaceDir) {
+  const args = JSON.parse(call.function.arguments);
+  switch (call.function.name) {
+    case "glob": {
+      const results = [];
+      async function findFiles(dir) {
+        try {
+          const entries = await readdir(dir, { withFileTypes: true });
+          for (const entry of entries) {
+            const full = join(dir, entry.name);
+            if (entry.isDirectory() && !entry.name.startsWith(".")) {
+              await findFiles(full);
+            } else if (entry.name.endsWith(".md")) {
+              results.push(full.replace(workspaceDir + "/", ""));
+            }
+          }
+        } catch {
+          /* ignore */
+        }
+      }
+      await findFiles(workspaceDir);
+      return results.length > 0 ? results.join("\n") : "(no .md files found)";
+    }
+    case "write": {
+      const filePath = join(workspaceDir, args.filePath);
+      const dir = filePath.substring(0, filePath.lastIndexOf("/"));
+      await mkdir(dir, { recursive: true }).catch(() => {});
+      await writeFile(filePath, args.content);
+      return `Written ${args.filePath} (${args.content.length} bytes)`;
+    }
+    case "read": {
+      try {
+        return await readFile(join(workspaceDir, args.filePath), "utf8");
+      } catch {
+        return "File not found";
+      }
+    }
+    default:
+      return `Tool ${call.function.name} not implemented in test mock`;
+  }
+}
+
+async function runExtraction(conversationMessages, workspaceDir) {
+  const conversationText = conversationMessages
+    .map((m) => `${m.role === "user" ? "User" : "Assistant"}: ${m.content}`)
+    .join("\n");
+
+  const messages = [
+    {
+      role: "system",
+      content:
+        "You are a memory extraction agent. Review the conversation and extract any user preferences, facts, or important information into memory files using the available tools.",
+    },
+    {
+      role: "user",
+      content: `# Existing memories (manifest)\nNo existing memories.\n\n# Recent conversation\n\n${conversationText}`,
+    },
+  ];
+
+  // Run the tool loop (max 5 iterations)
+  for (let i = 0; i < 5; i++) {
+    const response = await chat(messages);
+    const choice = response.choices?.[0];
+    if (!choice) {
+      console.log(`  iter ${i}: no choice`);
+      break;
+    }
+    console.log(
+      `  iter ${i}: finish_reason=${choice.finish_reason} tool_calls=${choice.message?.tool_calls?.length ?? 0}`,
+    );
+
+    if (choice.finish_reason === "tool_calls" && choice.message?.tool_calls?.length > 0) {
+      messages.push({ role: "assistant", content: null, tool_calls: choice.message.tool_calls });
+
+      for (const call of choice.message.tool_calls) {
+        console.log(`    executing ${call.function.name}(${call.function.arguments.slice(0, 80)})`);
+        const result = await executeTool(call, workspaceDir);
+        console.log(`    result: ${result.slice(0, 100)}`);
+        messages.push({ role: "tool", tool_call_id: call.id, content: result });
+      }
+    } else {
+      break;
+    }
+  }
+}
+
+// ─── main ──────────────────────────────────────────────────────────────────
+
+const workspaceDir = process.argv[2] ?? "/home/node/.openclaw/workspace";
+
+const prompts = process.argv.slice(3);
+if (prompts.length === 0) {
+  prompts.push(
+    "I love drinking green tea with honey in the mornings.",
+    "Please reply to me in a warm and friendly tone.",
+  );
+}
+
+for (const prompt of prompts) {
+  const conversationMessages = [
+    { role: "user", content: prompt },
+    { role: "assistant", content: "Sure, I'll remember that." },
+  ];
+  console.log(`Extracting: "${prompt.slice(0, 50)}..."`);
+  await runExtraction(conversationMessages, workspaceDir);
+}
+
+// Build MEMORY.md index from extracted files
+async function buildMemoryIndex(workspaceDir) {
+  const files = [];
+  async function findFiles(dir) {
+    try {
+      const entries = await readdir(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const full = join(dir, entry.name);
+        if (entry.isDirectory() && !entry.name.startsWith(".")) {
+          await findFiles(full);
+        } else if (entry.name.endsWith(".md") && entry.name !== "MEMORY.md") {
+          const relPath = full.replace(workspaceDir + "/", "");
+          const content = await readFile(full, "utf8");
+          files.push({ path: relPath, content });
+        }
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  await findFiles(workspaceDir);
+
+  if (files.length === 0) return;
+
+  const lines = ["# Memory Index", ""];
+  for (const f of files) {
+    const nameMatch = f.content.match(/name:\s*(.+)/);
+    const descMatch = f.content.match(/description:\s*(.+)/);
+    const name = nameMatch?.[1]?.trim() ?? f.path;
+    const desc = descMatch?.[1]?.trim() ?? "";
+    lines.push(`- [${name}](${f.path}) — ${desc}`);
+    const body = f.content.replace(/^---\n[\s\S]*?\n---\n*/, "").trim();
+    if (body) {
+      for (const line of body.split("\n")) {
+        lines.push(`  ${line}`);
+      }
+    }
+    lines.push("");
+  }
+
+  await writeFile(join(workspaceDir, "MEMORY.md"), lines.join("\n"));
+  console.log(`MEMORY.md created with ${files.length} entries`);
+}
+
+await buildMemoryIndex(workspaceDir);
+console.log("Extraction complete");


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

Fixes #

## Summary

- Add OpenClaw as the third agent in the data-driven K8s E2E framework (alongside Hermes and Pi)
- Reuse existing `cases.mjs` and `mock-llm` service — no changes to test data or core test infrastructure
- New files:
  - `e2e/kind/Dockerfile.openclaw` — OpenClaw image with memflywheel adapter baked in
  - `e2e/kind/openclaw-sandbox.yaml` — Sandbox CR based on [`agent-sandbox/examples/openclaw-sandbox@v0.5.0`](https://github.com/kubernetes-sigs/agent-sandbox/tree/v0.5.0/examples/openclaw-sandbox)
  - `e2e/kind/openclaw-config.yaml` — ConfigMap for OpenClaw gateway
  - `e2e/openclaw/chat.mjs` — recall-only lifecycle simulator (emits OpenClaw hook events through memflywheel adapter)
  - `e2e/openclaw/extract.mjs` — standalone extraction script (same pattern as Pi, since OpenClaw has no in-process model port)
- Updated `e2e/agents.mjs` with OpenClaw agent config (`chatFn`, `verifySetup`, `afterTurns`, `memoryPaths`)
- Updated `.github/workflows/e2e.yml` to build, load, deploy, and collect logs for OpenClaw sandbox
- Updated `e2e/kind/setup.sh` to create `openclaw-test` namespace

Test results: **Hermes 13/13 + Pi 10/10 + OpenClaw 11/11 = 34/34 passing**.

## Checks

- [x] `pnpm run ci`
- [x] No old project names, private paths, credentials, or AI-signature footers
- [x] Package metadata still points to `iflytek/memflywheel`
- [x] Core does not call LLMs directly
- [x] Recall remains full-index, with no embedding/BM25/top-k/vector retrieval

## Special notes for reviewers

This PR touches only `e2e/`, `.github/workflows/e2e.yml`, `.gitignore`, and `CHANGELOG.md` — no changes to core packages, adapters, or plugins.

Building on top of #36 (unified data-driven E2E framework).