### PR TITLE
Add DeepWiki badge to READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/iflytek/memflywheel/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/iflytek/memflywheel/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="node" src="https://img.shields.io/badge/node-%3E%3D22.13.0-339933">
   <a href="LICENSE"><img alt="license" src="https://img.shields.io/github/license/iflytek/memflywheel"></a>
+  <a href="https://deepwiki.com/iflytek/memflywheel"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"></a>
 </p>
 
 ![MemFlywheel overview](docs/assets/readme/01-overview.png)

--- a/README.zh.md
+++ b/README.zh.md
@@ -20,6 +20,7 @@
   <a href="https://github.com/iflytek/memflywheel/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/iflytek/memflywheel/actions/workflows/ci.yml/badge.svg"></a>
   <img alt="node" src="https://img.shields.io/badge/node-%3E%3D22.13.0-339933">
   <a href="LICENSE"><img alt="license" src="https://img.shields.io/github/license/iflytek/memflywheel"></a>
+  <a href="https://deepwiki.com/iflytek/memflywheel"><img alt="Ask DeepWiki" src="https://deepwiki.com/badge.svg"></a>
 </p>
 
 ![MemFlywheel overview](docs/assets/readme/01-overview.png)


### PR DESCRIPTION
## Summary

- add an Ask DeepWiki badge to the English README
- add the same badge to the Simplified Chinese README
- link both badges to the MemFlywheel page on DeepWiki

## Why

This gives readers a direct entry point to explore and ask questions about the repository through DeepWiki from either README.

## Impact

Documentation-only change; no runtime behavior is affected.

## Validation

- `git diff --check HEAD^ HEAD`