### PR TITLE
fix(release): skip GitHub Packages publish when version already exists

### DIFF
--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -80,7 +80,6 @@ function publishToGitHubPackages(publishArgs) {
       const pj = JSON.parse(readFileSync(pjPath, "utf8"));
 
       // Rewrite package name and dependency keys
-      const originalName = pj.name;
       pj.name = rewriteScope(pj.name);
       for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
         if (!pj[field]) continue;

--- a/scripts/publish-npm.mjs
+++ b/scripts/publish-npm.mjs
@@ -55,6 +55,14 @@ function publishToNpm(publishArgs) {
   }
 }
 
+function versionExistsOnRegistry(name, version, registry) {
+  const r = spawnSync("npm", ["view", `${name}@${version}`, "version", "--registry", registry], {
+    encoding: "utf8",
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  return r.status === 0 && r.stdout.trim() === version;
+}
+
 function publishToGitHubPackages(publishArgs) {
   const staging = mkdtempSync(join(tmpdir(), "ghpkg-"));
   try {
@@ -72,6 +80,7 @@ function publishToGitHubPackages(publishArgs) {
       const pj = JSON.parse(readFileSync(pjPath, "utf8"));
 
       // Rewrite package name and dependency keys
+      const originalName = pj.name;
       pj.name = rewriteScope(pj.name);
       for (const field of ["dependencies", "peerDependencies", "optionalDependencies"]) {
         if (!pj[field]) continue;
@@ -97,6 +106,12 @@ function publishToGitHubPackages(publishArgs) {
               console.warn(`Warning: failed to rewrite ${rel}: ${err.message}`);
           }
         }
+      }
+
+      // Skip if this version already exists on GitHub Packages
+      if (versionExistsOnRegistry(pj.name, pj.version, GHP_REGISTRY)) {
+        console.log(`[SKIP] ${pj.name}@${pj.version} already exists on GitHub Packages — skipping`);
+        continue;
       }
 
       run("npm", [


### PR DESCRIPTION
**Which issue(s) this PR fixes**:

> This is dry-run pass？
> _Originally posted by @dongjiang1989 in https://github.com/iflytek/memflywheel/pull/45#discussion_r3664310770_

Fixes the release workflow failure at https://github.com/iflytek/memflywheel/actions/runs/30351326253/job/90249842896

## Summary

The release workflow fails with `409 Conflict` when re-pushing an existing tag because GitHub Packages does not allow overwriting published versions.

```
npm error 409 Conflict - PUT https://npm.pkg.github.com/@iflytek%2fmemflywheel - Cannot publish over existing version
```

This PR adds a pre-publish check in `scripts/publish-npm.mjs`:
- `versionExistsOnRegistry()` uses `npm view` to check if the version already exists on GitHub Packages
- If it exists, skip with a `[SKIP]` message instead of failing
- Makes re-running the release workflow (e.g. re-pushing a tag) idempotent

## Checks

- [x] `pnpm run ci`
- [x] No old project names, private paths, credentials, or AI-signature footers
- [x] Package metadata still points to `iflytek/memflywheel`
- [x] Core does not call LLMs directly
- [x] Recall remains full-index, with no embedding/BM25/top-k/vector retrieval

## Special notes for reviewers

Only `scripts/publish-npm.mjs` is changed — no impact on core packages, adapters, plugins, or e2e tests.