### PR TITLE
fix(pi): run memory learning in background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ for published packages.
 
 ### Fixed
 
+- Moved Pi turn-end extraction, skill evolution, Dream, and learned-skill sync
+  onto a serialized background queue so completed answers no longer keep the
+  foreground `Working...` state active; session shutdown drains the queue and
+  surfaces background failures.
 - Reused OpenCode's host-owned OpenAI OAuth `fetch` transport for background
   memory agent loops without reading, copying, or persisting OAuth tokens.
 - Reported OpenCode background lifecycle failures through the host logger instead

--- a/packages/memflywheel/src/pi-port.test.ts
+++ b/packages/memflywheel/src/pi-port.test.ts
@@ -116,16 +116,69 @@ test("Pi context forwards the latest user query into progressive recall", async 
   assert.equal((result as { messages: unknown[] }).messages.length, 4);
 });
 
-test("Pi lifecycle hooks run only after host handlers complete", async () => {
+test("Pi turn-end learning runs off the foreground event and drains before shutdown", async () => {
   const { api, handlers } = fakePi();
   const order: string[] = [];
+  let releaseFirst: (() => void) | undefined;
+  const firstBlocked = new Promise<void>((resolve) => {
+    releaseFirst = resolve;
+  });
   const port = createPiHarnessPort(api, {
     resolveModel: async () => {
       throw new Error("unused");
     },
     afterTurnEnd: () => void order.push("sync"),
   });
-  port.lifecycle.onTurnEnd(async () => void order.push("turn"));
-  await handlers.get("agent_end")?.({ messages: [] }, {});
-  assert.deepEqual(order, ["turn", "sync"]);
+  port.lifecycle.onTurnEnd(async (event) => {
+    order.push(`start:${event.sessionId}`);
+    if (event.sessionId === "s1") await firstBlocked;
+    order.push(`end:${event.sessionId}`);
+  });
+  port.lifecycle.onSessionEnd(async (event) => void order.push(`shutdown:${event.sessionId}`));
+
+  const firstReturn = handlers.get("agent_end")?.({ sessionId: "s1", messages: [] }, {});
+  const secondReturn = handlers.get("agent_end")?.({ sessionId: "s2", messages: [] }, {});
+  assert.equal(firstReturn, undefined);
+  assert.equal(secondReturn, undefined);
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(order, ["start:s1"]);
+
+  const shutdown = handlers.get("session_shutdown")?.({ sessionId: "s2" }, {});
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(order, ["start:s1"]);
+  releaseFirst?.();
+  await shutdown;
+  assert.deepEqual(order, [
+    "start:s1",
+    "end:s1",
+    "sync",
+    "start:s2",
+    "end:s2",
+    "sync",
+    "shutdown:s2",
+  ]);
+});
+
+test("Pi reports background learning failures and rejects shutdown after the final sweep", async () => {
+  const { api, handlers } = fakePi();
+  const notifications: string[] = [];
+  const order: string[] = [];
+  const port = createPiHarnessPort(api, {
+    resolveModel: async () => {
+      throw new Error("unused");
+    },
+  });
+  port.lifecycle.onTurnEnd(async () => {
+    throw new Error("model unavailable");
+  });
+  port.lifecycle.onSessionEnd(async () => void order.push("final-sweep"));
+
+  handlers.get("agent_end")?.(
+    { sessionId: "s1", messages: [] },
+    { ui: { notify: (message) => notifications.push(message) } },
+  );
+  const shutdown = Promise.resolve(handlers.get("session_shutdown")?.({ sessionId: "s1" }, {}));
+  await assert.rejects(shutdown, /background learning failed/);
+  assert.deepEqual(order, ["final-sweep"]);
+  assert.deepEqual(notifications, ["MemFlywheel background learning failed: model unavailable"]);
 });

--- a/packages/memflywheel/src/pi-port.ts
+++ b/packages/memflywheel/src/pi-port.ts
@@ -69,6 +69,9 @@ export interface PiExtensionContextLike {
   };
   getThinkingLevel?(): unknown;
   isIdle?(): boolean;
+  ui?: {
+    notify?(message: string, type?: "info" | "warning" | "error"): void;
+  };
 }
 
 export type PiExtensionHandler = (
@@ -374,6 +377,10 @@ export function createPiHarnessPort(
 ): HostHarnessPort {
   let lastContext: PiExtensionContextLike | undefined;
   let lastSessionId: string | undefined;
+  let backgroundContext: PiExtensionContextLike | undefined;
+  let backgroundSessionId: string | undefined;
+  let backgroundTail = Promise.resolve();
+  const backgroundFailures: unknown[] = [];
   const rememberContext = (event?: unknown, ctx?: PiExtensionContextLike): void => {
     if (ctx) lastContext = ctx;
     lastSessionId = resolvePiSessionId(options.sessionId, event, ctx ?? lastContext);
@@ -385,13 +392,45 @@ export function createPiHarnessPort(
       ? createPiAgentModelResolver({
           streamSimple: options.streamSimple,
           model: options.piModel,
-          getContext: () => lastContext,
-          getSessionId: () => isolatedBackgroundModelSessionId(lastSessionId),
+          getContext: () => backgroundContext ?? lastContext,
+          getSessionId: () =>
+            isolatedBackgroundModelSessionId(backgroundSessionId ?? lastSessionId),
         })
       : undefined);
   if (!resolveModel) {
     throw new Error("createPiHarnessPort requires either resolveModel or Pi streamSimple");
   }
+
+  const reportBackgroundFailure = (error: unknown, ctx?: PiExtensionContextLike): void => {
+    const message = `MemFlywheel background learning failed: ${error instanceof Error ? error.message : String(error)}`;
+    if (ctx?.ui?.notify) ctx.ui.notify(message, "error");
+    else console.error(message);
+  };
+  const enqueueBackgroundTurn = (
+    sessionId: string,
+    ctx: PiExtensionContextLike | undefined,
+    task: () => Promise<void>,
+  ): void => {
+    backgroundTail = backgroundTail.then(async () => {
+      backgroundContext = ctx;
+      backgroundSessionId = sessionId;
+      try {
+        await task();
+      } catch (error) {
+        backgroundFailures.push(error);
+        reportBackgroundFailure(error, ctx);
+      } finally {
+        backgroundContext = undefined;
+        backgroundSessionId = undefined;
+      }
+    });
+  };
+  const drainBackgroundTurns = async (): Promise<void> => {
+    await backgroundTail;
+    if (backgroundFailures.length === 0) return;
+    const failures = backgroundFailures.splice(0);
+    throw new AggregateError(failures, "MemFlywheel background learning failed");
+  };
 
   const capabilities: HostCapability[] = [
     "prompt-build",
@@ -416,20 +455,36 @@ export function createPiHarnessPort(
       });
     },
     onTurnEnd(handler) {
-      return bindPiEvent(pi, "agent_end", async (event, ctx) => {
+      return bindPiEvent(pi, "agent_end", (event, ctx) => {
         rememberContext(event, ctx);
-        await handler({
-          sessionId: lastSessionId ?? "pi",
-          messages: hostMessagesFromPi(isRecord(event) ? event.messages : undefined),
+        const sessionId = lastSessionId ?? "pi";
+        const messages = hostMessagesFromPi(isRecord(event) ? event.messages : undefined);
+        enqueueBackgroundTurn(sessionId, ctx ?? lastContext, async () => {
+          await handler({ sessionId, messages });
+          await options.afterTurnEnd?.();
         });
-        await options.afterTurnEnd?.();
       });
     },
     onSessionEnd(handler) {
       return bindPiEvent(pi, "session_shutdown", async (event, ctx) => {
         rememberContext(event, ctx);
-        await handler({ sessionId: lastSessionId ?? "pi" });
-        await options.afterSessionEnd?.();
+        const sessionId = lastSessionId ?? "pi";
+        let drainError: unknown;
+        try {
+          await drainBackgroundTurns();
+        } catch (error) {
+          drainError = error;
+        }
+        backgroundContext = ctx ?? lastContext;
+        backgroundSessionId = sessionId;
+        try {
+          await handler({ sessionId });
+          await options.afterSessionEnd?.();
+        } finally {
+          backgroundContext = undefined;
+          backgroundSessionId = undefined;
+        }
+        if (drainError) throw drainError;
       });
     },
   };


### PR DESCRIPTION
## Summary

- enqueue Pi turn-end extraction, skill evolution, Dream, and learned-skill sync instead of awaiting them inside the foreground `agent_end` hook
- preserve strict FIFO ordering and the originating session/model context for every background turn
- report background failures through Pi native UI notifications and reject session shutdown after the final sweep
- drain pending work before `session_shutdown` completes so normal exits do not lose memory writes

## Why

Pi waits for extension `agent_end` promises before clearing its foreground working state. A real local run completed the assistant response at `16:49:07` but remained working until MemFlywheel finished at `16:50:15`, adding about 68 seconds of visible latency.

## Validation

- `pnpm run test` — 261 tests passed
- `pnpm run format:check`
- `git diff --check`
- real Pi 0.83.0 E2E using the configured `deepseek/deepseek-v4-flash` model:
  - assistant response completed at `17:00:00.230`
  - Pi emitted `agent_end` and `agent_settled` without waiting for memory work
  - typed memory was written asynchronously at `17:00:03.979`
  - Dream/index work continued in the background without holding the foreground lifecycle
  - a fresh session used Pi native `read` on the typed memory body and recalled the exact marker

## Lifecycle contract

```text
agent_end -> snapshot + enqueue -> return immediately
background queue -> extraction -> skill evolution -> Dream -> skill sync
session_shutdown -> drain queue -> final sweep -> cleanup
```

The foreground is eventually consistent with the memory store: a new session started immediately after an answer may begin before that turn has been extracted, while same-session conversation context remains available.